### PR TITLE
Adding constant contourID field to DATA in ARTwarp_Load_Data.m

### DIFF
--- a/ARTwarp_Load_Data.m
+++ b/ARTwarp_Load_Data.m
@@ -46,6 +46,7 @@ for c1 = 1:numSamples
     end
     if exist('countourID', 'var') %if the variable 'countourID' exists, make this the value in the DATA.contourID field
         DATA(c1).countourID = countourID;
+    end
     DATA(c1).category = 0; %category name set to 0 for the active contour
 end
 h = findobj('Tag', 'Runmenu'); %find the object Runmenu (which is in ARTwarp.m)                                                                                                                        

--- a/ARTwarp_Load_Data.m
+++ b/ARTwarp_Load_Data.m
@@ -44,8 +44,8 @@ for c1 = 1:numSamples
     else
         DATA(c1).tempres = DATA(c1).ctrlength/DATA(c1).length; %if it doesn't, tempres is found by using ctrlength divided by length
     end
-    if exist('countourID', 'var') %if the variable 'countourID' exists, make this the value in the DATA.contourID field
-        DATA(c1).countourID = countourID;
+    if exist('contourID', 'var') %if the variable 'contourID' exists, make this the value in the DATA.contourID field
+        DATA(c1).contourID = contourID;
     end
     DATA(c1).category = 0; %category name set to 0 for the active contour
 end

--- a/ARTwarp_Load_Data.m
+++ b/ARTwarp_Load_Data.m
@@ -44,6 +44,8 @@ for c1 = 1:numSamples
     else
         DATA(c1).tempres = DATA(c1).ctrlength/DATA(c1).length; %if it doesn't, tempres is found by using ctrlength divided by length
     end
+    if exist('countourID', 'var') %if the variable 'countourID' exists, make this the value in the DATA.contourID field
+        DATA(c1).countourID = countourID;
     DATA(c1).category = 0; %category name set to 0 for the active contour
 end
 h = findobj('Tag', 'Runmenu'); %find the object Runmenu (which is in ARTwarp.m)                                                                                                                        


### PR DESCRIPTION
This should allow a unique ID for each contour to be inputted and outputted from ARTwarp.

The unique IDs will be stored in a field "contourID" in the MATLAB struct object ([https://uk.mathworks.com/help/releases/R2024b/matlab/ref/struct.html](url)) named DATA, which is contained in the output file named ARTwarpxxFINAL.mat (where xx is the vigilance parameter that was supplied to the ART network by the user). I've briefly checked that the IDs inputted are the same when outputted, but have not formally tested that they stay constant throughout the program (though I can't see why they'd be modified by any other files).

Is this the kind of addition you were looking for @sullivan-james? 

Note it currently only adds this field for each contour if the .ctr file contains a variable "contourID" - is this how you were hoping the IDs would be inputted to ARTwarp or have I misunderstood?