### PR TITLE
Add in constant id field from id attribute in CTR file

### DIFF
--- a/ARTwarp_Load_Data.m
+++ b/ARTwarp_Load_Data.m
@@ -44,7 +44,17 @@ for c1 = 1:numSamples
     else
         DATA(c1).tempres = DATA(c1).ctrlength/DATA(c1).length; %if it doesn't, tempres is found by using ctrlength divided by length
     end
+
     DATA(c1).category = 0; %category name set to 0 for the active contour
+
+    DATA(c1).match = []; %match set initially to a null value (empty array) for the active contour
+
+    if exist('id', 'var') % if the variable 'id' exists, make this the value in the DATA.id field (this forms a unique identifier for each contour)
+        DATA(c1).id = id;
+        clear id; % then clear the id variable to avoid all subsequent contours being assigned the same ID!
+    else
+        DATA(c1).id = []; % otherwise, make the value in the DATA.id field [], to show that no ID has been assigned
+    end
 end
 h = findobj('Tag', 'Runmenu'); %find the object Runmenu (which is in ARTwarp.m)                                                                                                                        
-set(h, 'Enable', 'on'); %change its property to on so the menu in the ARTwarp window will be undimmed
+set(h, 'Enable', 'on'); %change its 'Enable' property to 'on' so the menu in the ARTwarp window will be undimmed


### PR DESCRIPTION
This PR adds in a constant "id" field to the DATA table (which is output as a .mat file after categorisation is complete). This allows each contour to be uniquely identified by its ID, which remains unchanged throughout the program.

The following images show this output DATA table for the cases where:

1.) All input CTR files contained an ID attribute "id":
![all_ids](https://github.com/user-attachments/assets/c01b1160-bbc5-49c3-a438-132d123ad159)

2.) Some (not all) CTR files contained an ID attribute "id":
![some_ids](https://github.com/user-attachments/assets/b230c7e2-1dac-49f8-b437-9ad5c5d82f0b)

3.) No CTR files contained an ID attribute "id":
![no_ids](https://github.com/user-attachments/assets/0e616c02-b970-4ee7-93c1-213dcf1352d7)

This is the same change as described in #66 but implemented the fixes described in the closing comment.