### PR TITLE
Initial commit of changes log for v1.0 and v1.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,50 @@
+# ARTwarp - history of changes
+
+## ARTwarp v1.1
+
+This release focusses on bug fixes and improved documentation.
+
+### New features
+
+-
+
+### Performance improvements
+
+- 
+
+### Improved and extended functionality
+
+- 
+
+### Removed or obsolete functionality
+
+-
+
+### Fixed bugs that could lead to incorrect results
+
+-
+
+### Fixed bugs that could lead to crashes
+
+- 
+
+### Other fixed bugs
+
+- 
+
+### Other changes
+
+- 
+
+
+## ARTwarp v1.0
+
+This is the first release made from the GitHub repository after its
+establishment, initially populating the repository with the content of 
+historic archives:
+
+- Version of 2003-11-25 ([417b267](https://github.com/dolphin-acoustics-vip/artwarp/commit/417b2673ec2a2b3fb55e8950ca89121665c9666c))
+
+- Version of 2019-01-11 ([953944e](https://github.com/dolphin-acoustics-vip/artwarp/commit/953944e967123f3b847d213d7c64ac43ed9146f9))
+
+- Version of 2021-10-01 ([fce0bc6](https://github.com/dolphin-acoustics-vip/artwarp/commit/fce0bc61534de3a055cb7b143dd6e321de94b9d6))


### PR DESCRIPTION
Closes #73.

Added a markdown file to log changes for the new release [v1.1](https://github.com/dolphin-acoustics-vip/artwarp/milestone/2). The layout and style of this changes log is taken directly from https://github.com/gap-system/gap/blob/master/CHANGES.md#gap-4150-september-2025.