### PR TITLE
Changed folder name to be loaded directly rather than using eval

### DIFF
--- a/ARTwarp_Load_Data.m
+++ b/ARTwarp_Load_Data.m
@@ -25,7 +25,11 @@ for c1 = 1:numSamples
     clear tempres
     clear ctrlength
     clear fcontour
-    eval(['load ' fullfile(DATA(c1).folder, DATA(c1).name) ' -mat']);
+    
+    % Parses the file name as a string variable
+    filename = fullfile(DATA(c1).folder, DATA(c1).name);
+    load(filename, '-mat'); % enforce reading the file as a MAT-file regardless of its extension
+    
     if exist('fcontour', 'var')
         DATA(c1).ctrlength = fcontour(length(fcontour))/1000;
         DATA(c1).length = length(fcontour);


### PR DESCRIPTION
Addresses Issue #95 

Requested by @olexandr-konovalov, this PR allows users to use folder directories and file names with spaces and/or singular quotes. 

This change in code has been tested on my Windows computer using a directory without spaces and a directory with spaces. In addition, it has been tested on a biologist's Macbook that had contour file names with spaces. In these cases, the code has run as expected without errors.

Tagged: @KaiKerlaff 