### PR TITLE
Add optional output folder parameter to the CLI

### DIFF
--- a/ARTwarp_Run_Categorisation.m
+++ b/ARTwarp_Run_Categorisation.m
@@ -279,6 +279,9 @@ for iterationNumber = 1:NET.maxNumIterations
 
     % Save iteration information to the specified results folder
     save(fullfile(output_folder, name)); 
+
+    % Output success message
+    fprintf('Results successfully exported to: %s\n', output_folder);
 end
 
 % ASSEMBLE THE REFCONTOURS STRUCT

--- a/ARTwarp_cli_mode.m
+++ b/ARTwarp_cli_mode.m
@@ -42,6 +42,9 @@ addRequired(p, 'resample', validationFcn);
 validationFcn = @(x) isnumeric(x) && isscalar(x);
 addRequired(p, 'sampleInterval', validationFcn);
 
+% Optional output folder name argument, default is empty
+addOptional(p, 'outputFolder', [], @(x) ischar(x) || isempty(x));
+
 % Parse and validate the input arguments (folder paths given must be to
 % folders, file path given must be to a file)
 parse(p, varargin{:});
@@ -68,14 +71,19 @@ end
 % RECOMMENDED FOR USE WHEN ABLE TO CONNECT TO OCEAN)
 localJobId = char(java.util.UUID.randomUUID);
 
-% and create the output folder using a name formed from the date and time,
+% and if no output folder name is specified,
+% create the output folder using a name formed from the date and time,
 % and first 7 characters of the localJobId, for local tracking of outputs
 % from recursive output runs
-filename_date = replace(char(datetime), {' ', ':'}, '-');
-outputFolder = ['LOCJOB' localJobId(1:7) 'AT' filename_date];
+if isempty(p.Results.outputFolder)
+    filename_date = replace(char(datetime), {' ', ':'}, '-');
+    outputFolder = ['LOCJOB' localJobId(1:7) 'AT' filename_date];
+else
+    outputFolder = char(p.Results.outputFolder);
+end
 
 if ~exist(outputFolder, 'dir')
-% If a folder with this name doesn't exist yet (and it shouldn't), make a
+% If a folder with this name doesn't exist yet, make a
 % new folder with the name specified by outputFolder
         mkdir(outputFolder);
 end

--- a/tst/test_load_and_categorise_csv_to_dir.m
+++ b/tst/test_load_and_categorise_csv_to_dir.m
@@ -1,0 +1,31 @@
+%T=readtable('../Test_Data/csv/Sb_HICEAS1706_20170913_AD259_S123_sel22_220035.csv')
+
+% GET ARTwarp ROOT PATH FOR REFERENCE WHILE RUNNING IN CONTINUOUS
+% INTEGRATION
+tstDir = fileparts(mfilename("fullpath"));
+ARTwarpRoot = fullfile(tstDir, '..');
+
+% Add the ARTwarp root path to the MATLAB path so we can run ARTwarp's
+% functions
+addpath(genpath(ARTwarpRoot))
+
+% CONVERT .csv FILES TO .ctr
+% read from the Test_Data/csv folder and convert .csvs to .ctrs
+
+% Format the absolute file path of the directory containing the .csvs
+csvDir = fullfile(ARTwarpRoot, 'Test_Data', 'csv');
+% Run TempRes3 to convert the .csvs at this location to .ctrs. Note that we
+% do not need to navigate to the ARTwarpRoot directory to run this, but
+% TempRes3 must be on the MATLAB path
+TempRes3(2, 0.005, csvDir)
+
+% CATEGORISE .ctr FILES USING ARTwarp_cli_mode.m
+% Note that we load data directly from Test_Data/csv as ARTwarp_Load_Data.m
+% automatically reads only the .ctr files in the folder. Note also that we
+% do not need to navigate to the ARTwarpRoot directory to run this, but
+% ARTwarp_cli_mode must be on the MATLAB path 
+
+% Categorise using the standard parameters warpFactorLevel = 3, vigilance =
+% 96, bias = 0.000001, learningRate = 0.1, maxNumCategories = 56,
+% maxNumIterations = 100, resample = 1, sampleInterval = 0.01.
+ARTwarp_cli_mode(csvDir, 3, 96, 0.000001, 0.1, 56, 100, 1, 0.01, 'Test_Output_Dir')


### PR DESCRIPTION
Closes #100 

As discussed with @KaiKerlaff, this feature enables the user to specify the output folder name when using the CLI version. Specifying the output folder name is optional. 

I have tested the feature by specifying output folder names 'saveHere' and 'save_here_1', as well as specifying no output folder as can be seen below. When no output folder name is specified, Kai's previous naming system is implemented (where the output folder consists of "LOCO" and the current date and time).

```bash
# Save to folder called saveHere
ARTwarp_cli_mode('OCEAN10', 3, 96, 0.000001, 0.1, 56, 100, 1, 0.01, 'saveHere')
# Save to folder called save_here
ARTwarp_cli_mode('OCEAN10', 3, 96, 0.000001, 0.1, 56, 100, 1, 0.01, 'save_here_1')
# No output folder specified
ARTwarp_cli_mode('OCEAN10', 3, 96, 0.000001, 0.1, 56, 100, 1, 0.01)
```

These commands have resulted in the success message of:
```bash
Results successfully exported to: <output_folder_name>
```

The output message informs the user that the CLI command executed successfully.