### PR TITLE
Default values and command builder for CLI version

### DIFF
--- a/ARTwarp_cli_builder.m
+++ b/ARTwarp_cli_builder.m
@@ -1,3 +1,4 @@
+function ARTwarp_cli_builder()
 % This file creates the CLI command based on the input parameters.
 
 % --- Required inputs (enforced) ---
@@ -137,3 +138,15 @@ cmd = sprintf('%s)', cmd);
 
 % Print the CLI command
 fprintf('\nGenerated command:\n%s\n', cmd);
+
+% Ask to run CLI mode directly
+while true
+    proceed = strtrim(input('\nDo you want to proceed? (y/n) ', 's'));
+    if lower(proceed) == 'y'
+        eval(cmd)
+        break;
+    elseif lower(proceed) == 'n'
+        break;
+    end
+    fprintf('Invalid input. Must be between y or n.\n');
+end

--- a/ARTwarp_cli_builder.m
+++ b/ARTwarp_cli_builder.m
@@ -1,0 +1,139 @@
+% This file creates the CLI command based on the input parameters.
+
+% --- Required inputs (enforced) ---
+
+% Input folder
+while true
+    % strtrim to ensure there are no leading or trailing spaces.
+    inputFolder = strtrim(input('Enter input folder name: ', 's'));
+    if ~isempty(inputFolder) && isfolder(inputFolder)
+        break;
+    end
+    fprintf('Invalid input. Please enter a valid folder name.\n');
+end
+
+% Warp factor level (>1, integer)
+while true
+    val = input('Enter warp factor level (1 <= integer <= 3): ');
+    if isnumeric(val) && isscalar(val) && val >= 1 && val <= 3 && mod(val,1)==0
+        warpFactorLevel = val;
+        break;
+    end
+    fprintf('Invalid input. Must be an integer between 1 and 3 inclusive.\n');
+end
+
+% Vigilance (1–99)
+while true
+    val = input('Enter vigilance (1–99, e.g. 95): ');
+    if isnumeric(val) && isscalar(val) && val >= 1 && val <= 99
+        vigilance = val;
+        break;
+    end
+    fprintf('Invalid input. Must be between 1 and 99.\n');
+end
+
+% Contour number / maximum number of categories (>=1 integer)
+while true
+    val = input('Enter number of contours / maximum number of categories (>=1): ');
+    if isnumeric(val) && isscalar(val) && val >= 1 && mod(val,1)==0
+        maxNumCategories = val;
+        break;
+    end
+    fprintf('Invalid input. Must be an integer >= 1.\n');
+end
+
+% Max iterations (>=1 integer)
+while true
+    val = input('Enter max iterations (>=1): ');
+    if isnumeric(val) && isscalar(val) && val >= 1 && mod(val,1)==0
+        maxNumIterations = val;
+        break;
+    end
+    fprintf('Invalid input. Must be an integer >= 1.\n');
+end
+
+% --- Defaults for optional parameters ---
+def.bias = 1e-6;
+def.learningRate = 0.1;
+def.resample = 1;
+def.sampleInterval = 0.01;
+
+fprintf('\n--- Optional parameters (press Enter to use default) ---\n');
+
+% Bias (>0)
+while true
+    tmp = input(sprintf('Bias (default %g): ', def.bias));
+    if isempty(tmp)
+        bias = def.bias;
+        break;
+    elseif isnumeric(tmp) && isscalar(tmp) && tmp > 0
+        bias = tmp;
+        break;
+    end
+    fprintf('Invalid input. Bias must be a positive number.\n');
+end
+
+% Learning rate (0 < lr <= 1)
+while true
+    tmp = input(sprintf('Learning rate (default %g): ', def.learningRate));
+    if isempty(tmp)
+        learningRate = def.learningRate;
+        break;
+    elseif isnumeric(tmp) && isscalar(tmp) && tmp > 0 && tmp <= 1
+        learningRate = tmp;
+        break;
+    end
+    fprintf('Invalid input. Must be between 0 and 1.\n');
+end
+
+% Resample (0 or 1)
+while true
+    tmp = input(sprintf('Resample? 1=yes, 0=no (default %d): ', def.resample));
+    if isempty(tmp)
+        resample = def.resample;
+        break;
+    elseif isnumeric(tmp) && isscalar(tmp) && (tmp == 0 || tmp == 1)
+        resample = tmp;
+        break;
+    end
+    fprintf('Invalid input. Must be 0 or 1.\n');
+end
+
+% Sample interval (>0)
+while true
+    tmp = input(sprintf('Sample interval (default %g seconds): ', def.sampleInterval));
+    if isempty(tmp)
+        sampleInterval = def.sampleInterval;
+        break;
+    elseif isnumeric(tmp) && isscalar(tmp) && tmp > 0
+        sampleInterval = tmp;
+        break;
+    end
+    fprintf('Invalid input. Must be a positive number.\n');
+end
+
+% Build command string to run the CLI
+cmd = sprintf("ARTwarp_cli_mode('%s', %d, %d, %d, %d", ...
+    inputFolder, warpFactorLevel, vigilance, maxNumCategories, maxNumIterations);
+
+% Only include optional paramameters if they are different from the defaults
+if bias ~= def.bias
+    cmd = sprintf('%s, ''bias'', %g', cmd, bias);
+end
+
+if learningRate ~= def.learningRate
+    cmd = sprintf('%s, ''learningRate'', %g', cmd, learningRate);
+end
+
+if resample ~= def.resample
+    cmd = sprintf('%s, ''resample'', %d', cmd, resample);
+end
+
+if sampleInterval ~= def.sampleInterval
+    cmd = sprintf('%s, ''sampleInterval'', %g', cmd, sampleInterval);
+end
+
+cmd = sprintf('%s)', cmd);
+
+% Print the CLI command
+fprintf('\nGenerated command:\n%s\n', cmd);

--- a/ARTwarp_cli_builder.m
+++ b/ARTwarp_cli_builder.m
@@ -58,6 +58,7 @@ def.bias = 1e-6;
 def.learningRate = 0.1;
 def.resample = 1;
 def.sampleInterval = 0.01;
+def.compareWarped = 0;
 
 fprintf('\n--- Optional parameters (press Enter to use default) ---\n');
 
@@ -113,6 +114,19 @@ while true
     fprintf('Invalid input. Must be a positive number.\n');
 end
 
+% compareWarped (0 or 1), default 0
+while true
+    tmp = input(sprintf('compareWarped? 1=yes, 0=no (default %d): ', def.compareWarped));
+    if isempty(tmp)
+        compareWarped = def.compareWarped;
+        break;
+    elseif isnumeric(tmp) && isscalar(tmp) && (tmp == 0 || tmp == 1)
+        compareWarped = tmp;
+        break;
+    end
+    fprintf('Invalid input. Must be 0 or 1.\n');
+end
+
 % Build command string to run the CLI
 cmd = sprintf("ARTwarp_cli_mode('%s', %d, %d, %d, %d", ...
     inputFolder, warpFactorLevel, vigilance, maxNumCategories, maxNumIterations);
@@ -132,6 +146,10 @@ end
 
 if sampleInterval ~= def.sampleInterval
     cmd = sprintf('%s, ''sampleInterval'', %g', cmd, sampleInterval);
+end
+
+if compareWarped ~= def.compareWarped
+    cmd = sprintf('%s, ''compareWarped'', %g', cmd, compareWarped);
 end
 
 cmd = sprintf('%s)', cmd);

--- a/ARTwarp_cli_mode.m
+++ b/ARTwarp_cli_mode.m
@@ -60,7 +60,7 @@ end
 % Optional argument to update weights according to warped contours, 1 =
 % update according to warped, 0 = update normally according to original.
 % Default is 0
-addOptional(p, 'compareWarped', 0, @(x) (x==0 || x==1) && isnumeric(x) && isscalar(x));
+addParameter(p, 'compareWarped', 0, @(x) (x==0 || x==1) && isnumeric(x) && isscalar(x));
 
 % Parse and validate the input arguments (folder paths given must be to
 % folders, file path given must be to a file)
@@ -103,16 +103,17 @@ params = dictionary("warpFactorLevel", warpFactorLevel, "vigilance",...
 
 % Print all parameters so user is aware of the input
 fprintf('\n--- INPUT PARAMETERS ---\n');
-fprintf('\ninputFolder\t : %s\n', inputFolder);
-fprintf('warpFactorLevel\t : %g\n', warpFactorLevel);
-fprintf('vigilance\t : %g\n', vigilance);
-fprintf('maxNumCategories : %d\n', maxNumCategories);
-fprintf('maxNumIterations : %d\n', maxNumIterations);
-fprintf('bias\t\t : %g\n', bias);
-fprintf('learningRate\t : %g\n', learningRate);
-fprintf('resample\t : %g\n', resample);
-fprintf('sampleInterval\t : %g\n', sampleInterval);
-fprintf('outputFolder\t : %s\n', outputFolder);
+fprintf('\ninputFolder       : %s\n', inputFolder);
+fprintf('warpFactorLevel   : %g\n', warpFactorLevel);
+fprintf('vigilance         : %g\n', vigilance);
+fprintf('maxNumCategories  : %d\n', maxNumCategories);
+fprintf('maxNumIterations  : %d\n', maxNumIterations);
+fprintf('bias              : %g\n', bias);
+fprintf('learningRate      : %g\n', learningRate);
+fprintf('resample          : %g\n', resample);
+fprintf('sampleInterval    : %g\n', sampleInterval);
+fprintf('compareWarped     : %d\n', compareWarped);
+fprintf('outputFolder      : %s\n', outputFolder);
 drawnow; % forces MATLAB to flush output immediately
 % LOAD DATA FROM SPECIFIED INPUT FOLDER
 

--- a/ARTwarp_cli_mode.m
+++ b/ARTwarp_cli_mode.m
@@ -47,8 +47,12 @@ addParameter(p, 'sampleInterval', 0.01, validationFcn);
 
 % If number of parameters is below expected, 
 % print usage, example usage, and end the program
-if nargin < 5
-    fprintf("\nUsage: ARTwarp_cli_mode('<input_folder_name>', '<warp_factor>', <vigilance>, <number_of_contours>, '<max_num_of_iterations>')\n");
+if nargin == 0
+    fprintf("\nYou did not specify input parameters. Now you can enter them interactively:\n")
+    run('ARTwarp_cli_builder.m')
+    return
+elseif nargin > 0 && nargin < 5
+    fprintf("\nUsage: ARTwarp_cli_mode('<input_folder_name>', <warp_factor>, <vigilance>, <number_of_contours>, <max_num_of_iterations>)\n");
     fprintf("For example: ARTwarp_cli_mode('ctr', 3, 95, 100, 100)\n");
     return
 end
@@ -87,7 +91,7 @@ outputFolder = inputFolder + "_" + string(vigilance) + "_" + string(warpFactorLe
 if ~exist(outputFolder, 'dir')
 % If a folder with this name doesn't exist yet, make a
 % new folder with the name specified by outputFolder
-        mkdir(outputFolder);
+    mkdir(outputFolder);
 end
 
 % PUT NETWORK PARAMETERS INTO A DICTIONARY

--- a/ARTwarp_cli_mode.m
+++ b/ARTwarp_cli_mode.m
@@ -17,15 +17,7 @@ addRequired(p, 'warpFactorLevel', validationFcn);
 validationFcn = @(x) (x >= 1) && (x <= 99) && isnumeric(x) && isscalar(x);
 addRequired(p, 'vigilance', validationFcn);
 
-% The bias
-validationFcn = @(x) (x >= 0) && (x <= 1) && isnumeric(x) && isscalar(x);
-addRequired(p, 'bias', validationFcn);
-
-% The learning rate
-validationFcn = @(x) (x > 0) && (x <= 1) && isnumeric(x) && isscalar(x);
-addRequired(p, 'learningRate', validationFcn);
-
-% The maximum number of categories
+% The maximum number of categories / number of contours
 validationFcn = @(x) (x >= 1) && mod(x,1)==0 && isnumeric(x) && isscalar(x);
 addRequired(p, 'maxNumCategories', validationFcn);
 
@@ -33,17 +25,33 @@ addRequired(p, 'maxNumCategories', validationFcn);
 validationFcn = @(x) (x >= 1) && mod(x,1)==0 && isnumeric(x) && isscalar(x);
 addRequired(p, 'maxNumIterations', validationFcn);
 
+% --- Optional parameters ---
+
+% The bias, default = 0.000001 (optional)
+validationFcn = @(x) (x >= 0) && (x <= 1) && isnumeric(x) && isscalar(x);
+addParameter(p, 'bias', 1e-6, validationFcn);
+
+% The learning rate, default = 0.1 (optional)
+validationFcn = @(x) (x > 0) && (x <= 1) && isnumeric(x) && isscalar(x);
+addParameter(p, 'learningRate', 0.1, validationFcn);
+
 % Whether the contours should be resampled before categorisation (1 for yes,)
 % 0 for no
+% default is 1 for yes to resample
 validationFcn = @(x) (x==0 || x==1) && isnumeric(x) && isscalar(x);
-addRequired(p, 'resample', validationFcn);
+addParameter(p, 'resample', 1, validationFcn);
 
-% The resampling interval
+% The resampling interval, default = 0.01s (10ms)
 validationFcn = @(x) isnumeric(x) && isscalar(x);
-addRequired(p, 'sampleInterval', validationFcn);
+addParameter(p, 'sampleInterval', 0.01, validationFcn);
 
-% Optional output folder name argument, default is empty
-addOptional(p, 'outputFolder', [], @(x) ischar(x) || isempty(x));
+% If number of parameters is below expected, 
+% print usage, example usage, and end the program
+if nargin < 5
+    fprintf("\nUsage: ARTwarp_cli_mode('<input_folder_name>', '<warp_factor>', <vigilance>, <number_of_contours>, '<max_num_of_iterations>')\n");
+    fprintf("For example: ARTwarp_cli_mode('ctr', 3, 95, 100, 100)\n");
+    return
+end
 
 % Optional argument to update weights according to warped contours, 1 =
 % update according to warped, 0 = update normally according to original.
@@ -73,20 +81,8 @@ if isempty(inputFolder)
     error('No input folder specified');
 end
 
-% CREATE A LOCAL JOB id FOR USER TO TRACK LOCAL RUNS WHILE OFFLINE (NOT
-% RECOMMENDED FOR USE WHEN ABLE TO CONNECT TO OCEAN)
-localJobId = char(java.util.UUID.randomUUID);
-
-% and if no output folder name is specified,
-% create the output folder using a name formed from the date and time,
-% and first 7 characters of the localJobId, for local tracking of outputs
-% from recursive output runs
-if isempty(p.Results.outputFolder)
-    filename_date = replace(char(datetime), {' ', ':'}, '-');
-    outputFolder = ['LOCJOB' localJobId(1:7) 'AT' filename_date];
-else
-    outputFolder = char(p.Results.outputFolder);
-end
+% Name the output folder based on the input folder, vigilance and warp factor
+outputFolder = inputFolder + "_" + string(vigilance) + "_" + string(warpFactorLevel);
 
 if ~exist(outputFolder, 'dir')
 % If a folder with this name doesn't exist yet, make a
@@ -101,6 +97,19 @@ params = dictionary("warpFactorLevel", warpFactorLevel, "vigilance",...
     maxNumIterations, "resample", resample, "sampleInterval",...
     sampleInterval, "compareWarped", compareWarped);
 
+% Print all parameters so user is aware of the input
+fprintf('\n--- INPUT PARAMETERS ---\n');
+fprintf('\ninputFolder: %s\n', inputFolder);
+fprintf('warpFactorLevel: %g\n', warpFactorLevel);
+fprintf('vigilance: %g\n', vigilance);
+fprintf('maxNumCategories: %d\n', maxNumCategories);
+fprintf('maxNumIterations: %d\n', maxNumIterations);
+fprintf('bias: %g\n', bias);
+fprintf('learningRate: %g\n', learningRate);
+fprintf('resample: %g\n', resample);
+fprintf('sampleInterval: %g\n', sampleInterval);
+fprintf('outputFolder: %s\n', outputFolder);
+drawnow; % forces MATLAB to flush output immediately
 % LOAD DATA FROM SPECIFIED INPUT FOLDER
 
 ARTwarp_Load_Data(true, inputFolder);

--- a/ARTwarp_cli_mode.m
+++ b/ARTwarp_cli_mode.m
@@ -99,16 +99,16 @@ params = dictionary("warpFactorLevel", warpFactorLevel, "vigilance",...
 
 % Print all parameters so user is aware of the input
 fprintf('\n--- INPUT PARAMETERS ---\n');
-fprintf('\ninputFolder: %s\n', inputFolder);
-fprintf('warpFactorLevel: %g\n', warpFactorLevel);
-fprintf('vigilance: %g\n', vigilance);
-fprintf('maxNumCategories: %d\n', maxNumCategories);
-fprintf('maxNumIterations: %d\n', maxNumIterations);
-fprintf('bias: %g\n', bias);
-fprintf('learningRate: %g\n', learningRate);
-fprintf('resample: %g\n', resample);
-fprintf('sampleInterval: %g\n', sampleInterval);
-fprintf('outputFolder: %s\n', outputFolder);
+fprintf('\ninputFolder\t : %s\n', inputFolder);
+fprintf('warpFactorLevel\t : %g\n', warpFactorLevel);
+fprintf('vigilance\t : %g\n', vigilance);
+fprintf('maxNumCategories : %d\n', maxNumCategories);
+fprintf('maxNumIterations : %d\n', maxNumIterations);
+fprintf('bias\t\t : %g\n', bias);
+fprintf('learningRate\t : %g\n', learningRate);
+fprintf('resample\t : %g\n', resample);
+fprintf('sampleInterval\t : %g\n', sampleInterval);
+fprintf('outputFolder\t : %s\n', outputFolder);
 drawnow; % forces MATLAB to flush output immediately
 % LOAD DATA FROM SPECIFIED INPUT FOLDER
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Press **Enter** to use the default value.
 - **learningRate** (default: `0.1`) - must be between 0 and 1
 - **resample** (default: `1`) - `1 = yes`, `0 = no`
 - **sampleInterval** (default: `0.01` seconds) - must be a positive number
-
+- **compareWarped** (default: `0`) - `1 = yes`, `0 = no`
 All optional inputs are validated. Invalid entries will trigger a re-prompt.
 
 ---
@@ -110,22 +110,23 @@ When the CLI command is executed, the following information is displayed:
 ```
 --- INPUT PARAMETERS ---
 
-inputFolder: <input folder name>
-warpFactorLevel: <warp factor>
-vigilance: <vigilance>
-bias: 1e-06
-learningRate: 0.1
-maxNumCategories: <maximum number of categories>
-maxNumIterations: <maximum number of iterations>
-resample: 1
-sampleInterval: 0.01
-outputFolder: <output folder name>
+inputFolder       : <input folder name>
+warpFactorLevel   : <warp factor>
+vigilance         : <vigilance>
+maxNumCategories  : <maximum number of categories>
+maxNumIterations  : <maximum number of iterations>
+bias              : 1e-06
+learningRate      : 0.2
+resample          : 1
+sampleInterval    : 0.01
+compareWarped     : 0
+outputFolder      : <output folder name>
 
 --- ITERATIONS ---
 
 Iteration <number> complete
-Reclassified samples: <number of samples>
-Current categories: <number of current categories classed>
+Reclassified samples  : <number of samples>
+Current categories    : <number of current categories classed>
 
 ARTwarp CLI mode run finished.
 Results successfully exported to: <input folder name>_<vigilance>_<warp factor>

--- a/README.md
+++ b/README.md
@@ -26,6 +26,110 @@ the end of each iteration.
 For further instructions on installing MATLAB and running ARTwarp, see 
 the ARTwarp Wiki: https://github.com/dolphin-acoustics-vip/artwarp/wiki
 
+## ARTwarp CLI Mode
+
+ARTwarp CLI mode enables execution of the ARTwarp algorithm directly from the Command Line Interface (CLI) by constructing and running a command string.
+
+### Building the Command String
+
+The CLI command can be created in two ways:
+- **Manual input** — directly writing the command in the terminal
+- **Automatic generation** — using the `ARTwarp_cli_builder` string builder
+
+In both cases, the command consists of **five required parameters** and **four optional parameters**.
+
+---
+#### Required inputs
+
+The following parameters must always be provided:
+
+- **inputFolder** - an existing folder name within this directory containing `.ctr` files
+- **warpFactorLevel** - the warping factor as an integer between 1 and 3 (inclusive)
+- **vigilance** - an integer between 1 and 99 (e.g. 95)
+- **maxNumCategories** - the number of contours / maximum number of categories as an integer greater than 1
+- **maxNumIterations** - the maximum number of iterations as an integer greater than 1
+
+All required inputs are validated. If an invalid value is entered, you will be prompted to re-enter it.
+
+---
+
+#### Optional Inputs
+Optional parameters can be configured after the required inputs.
+Press **Enter** to use the default value.
+
+- **bias** (default: `1e-6`) - must be a positive number
+- **learningRate** (default: `0.1`) - must be between 0 and 1
+- **resample** (default: `1`) - `1 = yes`, `0 = no`
+- **sampleInterval** (default: `0.01` seconds) - must be a positive number
+
+All optional inputs are validated. Invalid entries will trigger a re-prompt.
+
+---
+
+### Manual input
+
+The CLI command can be written directly in the terminal in the following format:
+
+```
+ARTwarp_cli_mode(inputFolder, warpFactorLevel, vigilance, contourNum, maxNumIterations, ...)
+```
+**Notes:**
+* The first five arguments are **required**
+* Optional parameters must be provided as name–value pairs
+* Only include optional parameters when deviating from default values
+
+#### Example
+
+```
+ARTwarp_cli_mode('ctrs', 2, 95, 10, 100, 'bias', 1e-5, 'resample', 0)
+```
+In this example:
+- The bias is set to `1e-5`, and note how both the 'bias' (parameter name) and 1e-5 (value) were appended to the end of the command.
+- Resample is disabled (0)
+---
+
+### Automated Command Generator (String Builder)
+
+The `ARTwarp_cli_builder` utility generates the command interactively based on user input.
+- Prompts for all required parameters
+- Prompts for optional parameters with defaults
+- Automatically validates all inputs
+- Appends optional parameters only if they differ from defaults
+
+#### Example output
+```
+Generated command:
+ARTwarp_cli_mode('data/input', 2, 95, 10, 100, 'learningRate', 0.2)
+```
+The generated command can be copied and executed directly in MATLAB.
+
+### Execution Output
+
+When the CLI command is executed, the following information is displayed:
+
+```
+--- INPUT PARAMETERS ---
+
+inputFolder: <input folder name>
+warpFactorLevel: <warp factor>
+vigilance: <vigilance>
+bias: 1e-06
+learningRate: 0.1
+maxNumCategories: <maximum number of categories>
+maxNumIterations: <maximum number of iterations>
+resample: 1
+sampleInterval: 0.01
+outputFolder: <output folder name>
+
+--- ITERATIONS ---
+
+Iteration <number> complete
+Reclassified samples: <number of samples>
+Current categories: <number of current categories classed>
+
+ARTwarp CLI mode run finished.
+Results successfully exported to: <input folder name>_<vigilance>_<warp factor>
+```
 
 ## Resources
 

--- a/tst/test_load_and_categorise_csv.m
+++ b/tst/test_load_and_categorise_csv.m
@@ -28,4 +28,4 @@ TempRes3(true, 2, 0.005, csvDir)
 % Categorise using the standard parameters warpFactorLevel = 3, vigilance =
 % 96, bias = 0.000001, learningRate = 0.1, maxNumCategories = 56,
 % maxNumIterations = 100, resample = 1, sampleInterval = 0.01.
-ARTwarp_cli_mode(csvDir, 3, 96, 0.000001, 0.1, 56, 100, 1, 0.01)
+ARTwarp_cli_mode(csvDir, 3, 96, 56, 100)

--- a/tst/test_load_and_categorise_csv_to_dir.m
+++ b/tst/test_load_and_categorise_csv_to_dir.m
@@ -28,4 +28,5 @@ TempRes3(true, 2, 0.005, csvDir)
 % Categorise using the standard parameters warpFactorLevel = 3, vigilance =
 % 96, bias = 0.000001, learningRate = 0.1, maxNumCategories = 56,
 % maxNumIterations = 100, resample = 1, sampleInterval = 0.01.
-ARTwarp_cli_mode(csvDir, 3, 96, 0.000001, 0.1, 56, 100, 1, 0.01, 'Test_Output_Dir')
+% Command format: ARTwarp_cli_mode('<input_folder_name>', <warp_factor>, <vigilance>, <number_of_contours>, <max_num_of_iterations>)
+ARTwarp_cli_mode(csvDir, 3, 96, 56, 100)

--- a/tst/test_load_and_categorise_with_compare_warped.m
+++ b/tst/test_load_and_categorise_with_compare_warped.m
@@ -27,4 +27,5 @@ TempRes3(true, 2, 0.005, csvDir)
 % 96, bias = 0.000001, learningRate = 0.1, maxNumCategories = 56,
 % maxNumIterations = 100, resample = 1, sampleInterval = 0.01, and
 % compareWarped = 1
-ARTwarp_cli_mode(csvDir, 3, 96, 0.000001, 0.1, 56, 100, 1, 0.01, 'Test_Output_Dir', 1)
+% Command format: ARTwarp_cli_mode('<input_folder_name>', <warp_factor>, <vigilance>, <number_of_contours>, <max_num_of_iterations>)
+ARTwarp_cli_mode(csvDir, 3, 96, 56, 100, 'compareWarped', 1)


### PR DESCRIPTION
## Description
As discussed with @KaiKerlaff and Rosie, this PR includes two changes to the CLI: 
1. Changing some parameters to optional with default values
2. Adding a command string builder

Originally, printing iteration numbers was apart of this PR but this has now been merged separately as PR #113. 

### 1. Default values
I have been in contact with Rosie about which values are unchanged during ARTwarp and setting default values to those to save time from manually having to type them for each run.

The required parameters are now:
* Input folder name	
* Warp factor level
* Vigilance
* Number of contours
* Maximum number of iterations
* Output folder name

Optional parameters:
* Bias
* Learning rate
* Resample
* Sample interval

When running ARTwarp CLI, all values are printed at the start of execution so the user is aware of all the parameter values. 

For example, the below is printed in the terminal after running `ARTwarp_cli_mode('OCEAN10', 3, 95, 100, 100)`
```bash
inputFolder       : 'OCEAN10'
warpFactorLevel   : 3
vigilance         : 95
maxNumCategories  : 100
maxNumIterations  : 100
bias              : 1e-06
learningRate      : 0.2
resample          : 1
sampleInterval    : 0.01
compareWarped     : 0
outputFolder      : 'OCEAN10_3_95'
```

Note: Rosie requested that the output folder should be named the input folder name plus the vigilance and the warp factor level. Therefore, output folder name is not an input parameter.

### 2. CLI string builder
As Pedro suggested, I have created a string builder which asks the user for each parameter and generates the command with the specified parameters to use the CLI. Pedro has implemented this in his Python version and it is useful for biologists who may be unsure on how to write the command for the CLI with the values they want.

Example:
```bash
>> ARTwarp_cli_builder
Enter input folder name: OCEAN100
Enter warp factor level (1 <= integer <= 3): 3
Enter vigilance (1–99, e.g. 95): 95
Enter number of contours (>=1): 100
Enter max iterations (>=1): 100

--- Optional parameters (press Enter to use default) ---
Bias (default 1e-06): 
Learning rate (default 0.1): 
Resample? 1=yes, 0=no (default 1):
Sample interval (default 0.01 seconds): 

Generated command:
ARTwarp_cli_mode('OCEAN100', 3, 95, 100, 100)
```

## Testing
I have tested the string builder and default values with various combinations of required and optional inputs. For example, toggling resample with the string builder, changing the learning rate manually, etc. 
I have then run the command built by the string builder and tested that the iteration numbers print in order and the success message is output at the end along with the output folder specified.