### PR TITLE
Add unit tests

### DIFF
--- a/tst/test_ARTwarp_Activate_Categories.m
+++ b/tst/test_ARTwarp_Activate_Categories.m
@@ -1,0 +1,36 @@
+% Define a global variable warpFactorLevel for testing (needed for the
+% warp.m function to run, but cleared at the end of this script)
+global warpFactorLevel;
+warpFactorLevel = 3;
+
+% Define an input contour and a weights matrix (containing 2 reference
+% contours) for testing. The first ref contour is [1,2,3,4,5]'=input and
+% the second is [1,0,0,0,0]
+input = [1;2;3;4;5];
+weight = [1,1;2,0;3,0;4,0;5,0];
+bias = 0.000001;
+
+% Try providing ARTwarp_Activate_Categories.m only 2 parameters, and check
+% an error is thrown.
+try
+    categoryAct = ARTwarp_Activate_Categories(input);
+    error("ARTwarp_Activate_Categories accepted incorrect number of input parameters")
+% If the error is correctly thrown, then run ARTwarp_Activate_Categories on
+% input, weight and bias.
+catch
+    categoryAct = ARTwarp_Activate_Categories(input, weight, bias);
+
+    % assert that the first reference contour reults in an activation value
+    % of 100% * bias, and a warping function of [1,2,3,4,5] (linear warping)
+    assert(categoryAct{1,1}(1,1) == 100*(1-bias))
+    assert(sum(categoryAct{2,1} == [1,2,3,4,5]) == 5)
+
+    % assert that the second reference contour reults in an activation value
+    % of 0, and a warping function of [] (indicating warping was not possible)
+    % due to lengths differing by a factor >= 3.
+    assert(categoryAct{1,1}(1,2) == 0)
+    assert(isempty(categoryAct{2,2}))
+end
+
+% Clear global variable warpFactorLevel and all local variables
+clear;

--- a/tst/test_ARTwarp_Create_Figure.m
+++ b/tst/test_ARTwarp_Create_Figure.m
@@ -1,0 +1,32 @@
+% Define global variable NET for testing (needed to format the figure in
+% ARTwarp_Create_Figure.m
+global NET
+
+% Populate NET.maxNumCategories with some small value (the only field
+% used by ARTwarp_Create_Figure.m)
+maxNumCategories = 10;
+NET = struct('maxNumCategories', {maxNumCategories});
+
+% GENERATE 'dummy' FIGURE with 'ARTwarp' tag as in ARTwarp_csv.m
+% Kept other properties the same as in ARTwarp_csv.m, but likely some of
+% these do not need to be defined here for testing
+h0 = figure('Units','normalized', ...
+    'CloseRequestFcn','callback1', ...
+    'Color',[0.752941176470588 0.752941176470588 0.752941176470588], ...
+    'MenuBar','none', ...
+    'Name','ART2 Neural Network', ...
+    'NumberTitle','off', ...
+    'PaperPosition',[18 180 576 432], ...
+    'PaperUnits','points', ...
+    'Position',[0 0.04036458333333333 1 0.8671875], ...
+    'Tag','ARTwarp');
+
+% Run ARTwarp_Create_Figure.m
+ARTwarp_Create_Figure
+
+% Close the window
+close(gcf)
+
+% Clear all variables from workspace
+clear
+

--- a/tst/test_ARTwarp_Get_Parameters.m
+++ b/tst/test_ARTwarp_Get_Parameters.m
@@ -1,0 +1,18 @@
+% Define global variables for testing (needed to display default values for
+% uimenu objects, but cleared at the end of this script)
+global warpFactorLevel vigilance bias learningRate maxNumCategories maxNumIterations sampleInterval resample
+
+% Set warpFactorLevel to 3 by default
+warpFactorLevel = 3;
+
+% Load the rest of the default values from 'Default.mat'
+load('../Default.mat')
+
+% Run ARTwarp_Get_Parameters.m
+ARTwarp_Get_Parameters
+
+% Close the window
+close(gcf)
+
+% Clear all variables from workspace
+clear

--- a/tst/test_ARTwarp_Plot_Net.m
+++ b/tst/test_ARTwarp_Plot_Net.m
@@ -1,0 +1,52 @@
+% Define global variables NET and DATA for testing (needed to provide some
+% 'dummy' data to plot
+global NET DATA
+
+% Populate required fields of NET and DATA with some 'dummy' data (only
+% fields used by ARTwarp_Plot_Net.m)
+
+% reference contours [1,2,3,4,5]' and [1,0,0,0,0]'
+weight = [1,1;2,0;3,0;4,0;5,0];
+% number of categories = 2
+numCategories = 2;
+% number of datapoints of longest ref contour = 5
+numFeatures = 5;
+% initialise NET struct with the above field values
+NET = struct('weight', {weight}, 'numCategories', {numCategories},...
+    'numFeatures', {numFeatures});
+
+% dummy contour names
+name = {'ctr1','ctr2','ctr3','ctr4'};
+% dummy contours
+contour = {[1,2,3,4,5], [1,2,3,4,5], [1,2,3,4,5], [1,0,0,0,0]};
+% categories these contours would have been placed in
+category = {1, 1, 1, 2};
+% and matches to these categories (all match=100 as these are just copies
+% of the reference contours in NET.weight)
+match = {100, 100, 100, 100};
+% initialise DATA struct with the above field values
+DATA = struct('category', category, 'name', name, 'match', match, 'contour',...
+    contour);
+
+% GENERATE 'dummy' FIGURE with 'ARTwarp' tag as in ARTwarp_csv.m
+% Kept other properties the same as in ARTwarp_csv.m, but likely some of
+% these do not need to be defined here for testing
+h0 = figure('Units','normalized', ...
+    'CloseRequestFcn','callback1', ...
+    'Color',[0.752941176470588 0.752941176470588 0.752941176470588], ...
+    'MenuBar','none', ...
+    'Name','ART2 Neural Network', ...
+    'NumberTitle','off', ...
+    'PaperPosition',[18 180 576 432], ...
+    'PaperUnits','points', ...
+    'Position',[0 0.04036458333333333 1 0.8671875], ...
+    'Tag','ARTwarp');
+
+% Run ARTwarp_Plot_Net.m
+ARTwarp_Plot_Net
+
+% Close the window
+close(gcf)
+
+% Clear all variables from workspace
+clear

--- a/tst/test_ARTwarp_Plot_Net2.m
+++ b/tst/test_ARTwarp_Plot_Net2.m
@@ -1,0 +1,52 @@
+% Define global variables NET and DATA for testing (needed to provide some
+% 'dummy' data to plot
+global NET DATA
+
+% Populate required fields of NET and DATA with some 'dummy' data (only
+% fields used by ARTwarp_Plot_Net2.m)
+
+% reference contours [1,2,3,4,5]' and [1,0,0,0,0]'
+weight = [1,1;2,0;3,0;4,0;5,0];
+% number of categories = 2
+numCategories = 2;
+% number of datapoints of longest ref contour = 5
+numFeatures = 5;
+% initialise NET struct with the above field values
+NET = struct('weight', {weight}, 'numCategories', {numCategories},...
+    'numFeatures', {numFeatures});
+
+% dummy contour names
+name = {'ctr1','ctr2','ctr3','ctr4'};
+% dummy contours
+contour = {[1,2,3,4,5], [1,2,3,4,5], [1,2,3,4,5], [1,0,0,0,0]};
+% categories these contours would have been placed in
+category = {1, 1, 1, 2};
+% and matches to these categories (all match=100 as these are just copies
+% of the reference contours in NET.weight)
+match = {100, 100, 100, 100};
+% initialise DATA struct with the above field values
+DATA = struct('category', category, 'name', name, 'match', match, 'contour',...
+    contour);
+
+% GENERATE 'dummy' FIGURE with 'ARTwarp' tag as in ARTwarp_csv.m
+% Kept other properties the same as in ARTwarp_csv.m, but likely some of
+% these do not need to be defined here for testing
+h0 = figure('Units','normalized', ...
+    'CloseRequestFcn','callback1', ...
+    'Color',[0.752941176470588 0.752941176470588 0.752941176470588], ...
+    'MenuBar','none', ...
+    'Name','ART2 Neural Network', ...
+    'NumberTitle','off', ...
+    'PaperPosition',[18 180 576 432], ...
+    'PaperUnits','points', ...
+    'Position',[0 0.04036458333333333 1 0.8671875], ...
+    'Tag','ARTwarp');
+
+% Run ARTwarp_Plot_Net2.m
+ARTwarp_Plot_Net2
+
+% Close the window
+close(gcf)
+
+% Clear all variables from workspace
+clear

--- a/tst/test_ARTwarp_csv.m
+++ b/tst/test_ARTwarp_csv.m
@@ -1,0 +1,11 @@
+% Call ARTwarp_csv.m to check no runtime errors are thrown when creating
+% the main figure object. This unit test should be further developed using
+% MATLAB's app testing framework to check the correct function of all
+% uimenu objects, and that the uimenu callbacks are executed correctly.
+ARTwarp_csv
+
+% Close the window
+close(gcf)
+
+% Clear all variables from workspace
+clear


### PR DESCRIPTION
Added six basic unit tests, one for each file listed in the 'commits' section above. Note that the tests for `ARTwarp_Get_Parameters.m`, `ARTwarp_Create_Figure.m`, `ARTwarp_Plot_Net.m`, `ARTwarp_Plot_Net2.m` and `ARTwarp_csv.m` particularly only test that the scripts run without error, and do not explicitly test the creation of GUI objects or the correct function of `uimenu` object callbacks. More work will be needed on these and future unit tests, but for now this improves code coverage by ~45%.