### PR TITLE
Display iteration numbers and successful terminal output for the CLI

### DIFF
--- a/ARTwarp_Run_Categorisation.m
+++ b/ARTwarp_Run_Categorisation.m
@@ -270,8 +270,8 @@ for iterationNumber = 1:NET.maxNumIterations
     
     if is_cli_mode
         fprintf('\nIteration %d complete\n', iterationNumber);
-        fprintf('Reclassified samples: %d\n', numChanges);
-        fprintf('Current categories: %d\n', NET.numCategories);
+        fprintf('Reclassified samples : %d\n', numChanges);
+        fprintf('Current categories   : %d\n', NET.numCategories);
         drawnow;
     end
     

--- a/ARTwarp_Run_Categorisation.m
+++ b/ARTwarp_Run_Categorisation.m
@@ -126,6 +126,8 @@ end
 
 % TRAINING
 [x, sortedRandom] = sort(randn(numSamples, 1)); %randomize the list of contours
+
+fprintf("\n--- ITERATIONS ---\n");
 % Go through the data once for every iteration.
 for iterationNumber = 1:NET.maxNumIterations
     
@@ -265,6 +267,14 @@ for iterationNumber = 1:NET.maxNumIterations
     end
     % If no new categories were added, and no inputs were reclassified in the current iteration
     % then we've reached equilibrium. Thus, we can stop training.
+    
+    if is_cli_mode
+        fprintf('\nIteration %d complete\n', iterationNumber);
+        fprintf('Reclassified samples: %d\n', numChanges);
+        fprintf('Current categories: %d\n', NET.numCategories);
+        drawnow;
+    end
+    
     if numChanges == 0
         break;
     end  
@@ -279,9 +289,6 @@ for iterationNumber = 1:NET.maxNumIterations
 
     % Save iteration information to the specified results folder
     save(fullfile(output_folder, name)); 
-
-    % Output success message
-    fprintf('Results successfully exported to: %s\n', output_folder);
 end
 
 % ASSEMBLE THE REFCONTOURS STRUCT
@@ -369,6 +376,10 @@ end
 formatSpec = 'ARTwarp%02.0fFINAL';
 endname = sprintf(formatSpec,NET.vigilance);
 save(fullfile(output_folder, endname)); 
+
+% Output success message
+fprintf('\nARTwarp CLI mode run finished.\n');
+fprintf('Results successfully exported to: %s\n', output_folder);
 
 % Re-enable GUI options if not running in cli mode
 if ~is_cli_mode


### PR DESCRIPTION
# Iteration numbers added to the CLI

This feature was taken from PR #106 and submitted as a separate PR for easier review.

## Description

I have added output to `ARTwarp_Run_Categorisation.m` as requested by Rosie to show the number of reclassified samples and current categories for each iteration. In addition, a success message is output at the end of the run to inform the user that the command has executed successfully.

An example of a run:
```
>> ARTwarp_cli_mode('OCEAN100', 3, 95, 100, 100)

--- INPUT PARAMETERS ---

inputFolder: OCEAN100
warpFactorLevel: 3
vigilance: 95
maxNumCategories: 100
maxNumIterations: 100
bias: 1e-06
learningRate: 0.1
resample: 1
sampleInterval: 0.01
outputFolder: OCEAN100_95_3

--- ITERATIONS ---

Iteration 1 complete
Reclassified samples: 100
Current categories: 30

Iteration 2 complete
Reclassified samples: 5
Current categories: 30

Iteration 3 complete
Reclassified samples: 1
Current categories: 30

Iteration 4 complete
Reclassified samples: 0
Current categories: 30

ARTwarp CLI mode run finished.
Results successfully exported to: OCEAN100_95_3
```