### PR TITLE
Add missing argument to TempRes3 call

### DIFF
--- a/tst/test_load_and_categorise_csv_to_dir.m
+++ b/tst/test_load_and_categorise_csv_to_dir.m
@@ -17,7 +17,7 @@ csvDir = fullfile(ARTwarpRoot, 'Test_Data', 'csv');
 % Run TempRes3 to convert the .csvs at this location to .ctrs. Note that we
 % do not need to navigate to the ARTwarpRoot directory to run this, but
 % TempRes3 must be on the MATLAB path
-TempRes3(2, 0.005, csvDir)
+TempRes3(true, 2, 0.005, csvDir)
 
 % CATEGORISE .ctr FILES USING ARTwarp_cli_mode.m
 % Note that we load data directly from Test_Data/csv as ARTwarp_Load_Data.m


### PR DESCRIPTION
@olexandr-konovalov failing CI test seems to be due to a missing argument in a call to `TempRes3` from `tst/test_load_and_categorise_csv_to_dir.m` here:
https://github.com/dolphin-acoustics-vip/artwarp/blob/215102f58a486c72a27e2faf0b0a72add18d2095/tst/test_load_and_categorise_csv_to_dir.m#L20
which should have had argument `is_cli_mode = true`. I have now added this and have passing CI tests on my branch.

I suggest this is high priority to merge, but will wait on your review first, to check that I am seeing this correctly.