### PR TITLE
Add conditional statement to catch zero-contour categories

### DIFF
--- a/ARTwarp_Average_Weights.m
+++ b/ARTwarp_Average_Weights.m
@@ -25,26 +25,31 @@ function updatedWeight = ARTwarp_Average_Weights(weight, inputLengths, inputCate
 
 % For every category:
 for cat = 1:numCategories
-
-    % Find all elements of the reference contour for that category which are not NaN
-    i = weight(:,cat);
-    i = i(i>0);
-    weightLength = length(i);
-
-    % Find new length from the average length of contours in that category
-    newLength = round(mean(inputLengths(inputCategories==cat)));
-
-    % interpolate (warp) the weight to a new spacing of (weightLength-1)/
-    % (newLength-1). This ensures the weight has newLength
-    % points, while retaining the same shape
-    newWeight = interp1(1:weightLength, i, 1:(weightLength-1)/(newLength-1):weightLength);
-
-    % Update the associated column in the weight matrix to hold the updated
-    % reference contour, padding the end with NaNs to maintain the dimensions
-    % of the matrix.            
-    weight(:,cat) = zeros(numFeatures,1).*NaN;
-    weight(1:newLength,cat) = newWeight';
     
+    % Get the lengths of contours in that category
+    contourLengths = inputLengths(inputCategories==cat);
+
+    % If there were any contours in that category:
+    if ~isempty(contourLengths)
+        % Find all elements of the reference contour for that category which are not NaN
+        i = weight(:,cat);
+        i = i(i>0);
+        weightLength = length(i);
+    
+        % Find new length from the average length of contours in that category
+        newLength = round(mean(contourLengths));
+    
+        % interpolate (warp) the weight to a new spacing of (weightLength-1)/
+        % (newLength-1). This ensures the weight has newLength
+        % points, while retaining the same shape
+        newWeight = interp1(1:weightLength, i, 1:(weightLength-1)/(newLength-1):weightLength);
+    
+        % Update the associated column in the weight matrix to hold the updated
+        % reference contour, padding the end with NaNs to maintain the dimensions
+        % of the matrix.            
+        weight(:,cat) = zeros(numFeatures,1).*NaN;
+        weight(1:newLength,cat) = newWeight';
+    end
 end
 
 updatedWeight = weight;


### PR DESCRIPTION
@olexandr-konovalov following a report of an error from @RosieDay-Reader, I have realised that there was a logic error in `ARTwarp_Average_Weights.m`, where if a category has zero contours assigned to it, then the following line assigns `newLength` a value of NaN when calculating the new length of the reference contour:
https://github.com/dolphin-acoustics-vip/artwarp/blob/62f91ed55fcc23807dd4484a9dd44a851279c2f6/ARTwarp_Average_Weights.m#L35
And this results in a 'non-finite index for colon operator' error when assigning the averaged reference contour to the weight matrix here:
https://github.com/dolphin-acoustics-vip/artwarp/blob/62f91ed55fcc23807dd4484a9dd44a851279c2f6/ARTwarp_Average_Weights.m#L46
I suggest this is a high priority for merging and should be released with v2.0. This error was not caught by the CI tests because the autogenerated test contours are only a small dataset and so no zero-contour categories were ever generated during test runs.