### PR TITLE
Add option to specify output folder name for CLI

### DIFF
--- a/ARTwarp_cli_builder.m
+++ b/ARTwarp_cli_builder.m
@@ -60,6 +60,7 @@ def.resample = 1;
 def.sampleInterval = 0.01;
 def.compareWarped = 0;
 def.recatSingleCats = 0;
+def.outputFolder = '';
 
 fprintf('\n--- Optional parameters (press Enter to use default) ---\n');
 
@@ -69,7 +70,7 @@ while true
     if isempty(tmp)
         bias = def.bias;
         break;
-    elseif isnumeric(tmp) && isscalar(tmp) && tmp > 0
+    elseif isnumeric(tmp) && isscalar(tmp) && tmp >= 0 && tmp <= 1
         bias = tmp;
         break;
     end
@@ -141,6 +142,15 @@ while true
     fprintf('Invalid input. Must be 0 or 1.\n');
 end
 
+% Output folder name
+% strtrim to ensure there are no leading or trailing spaces.
+tmp = strtrim(input('Enter output folder name (optional): ', 's'));
+if isempty(tmp)
+    outputFolder = def.outputFolder;
+else
+    outputFolder = tmp;
+end
+
 % Build command string to run the CLI
 cmd = sprintf("ARTwarp_cli_mode('%s', %d, %d, %d, %d", ...
     inputFolder, warpFactorLevel, vigilance, maxNumCategories, maxNumIterations);
@@ -168,6 +178,10 @@ end
 
 if recatSingleCats ~= def.recatSingleCats
     cmd = sprintf('%s, ''recatSingleCats'', %g', cmd, recatSingleCats);
+end
+
+if ~strcmp(outputFolder, def.outputFolder)
+    cmd = sprintf('%s, ''outputFolder'', ''%s''', cmd, outputFolder);
 end
 
 cmd = sprintf('%s)', cmd);

--- a/ARTwarp_cli_mode.m
+++ b/ARTwarp_cli_mode.m
@@ -55,6 +55,9 @@ addParameter(p, 'compareWarped', 0, @(x) (x==0 || x==1) && isnumeric(x) && issca
 % not try to recategorise. Default is 0
 addParameter(p, 'recatSingleCats', 0, @(x) (x==0 || x==1) && isnumeric(x) && isscalar(x));
 
+% Optional output folder name argument, default is empty
+addParameter(p, 'outputFolder', "", @(x) isstring(x) || ischar(x) || isempty(x));
+
 % If number of parameters is below expected, 
 % print usage, example usage, and end the program
 if nargin == 0
@@ -85,14 +88,18 @@ resample = p.Results.resample;
 sampleInterval = p.Results.sampleInterval;
 compareWarped = p.Results.compareWarped;
 recatSingleCats = p.Results.recatSingleCats;
+outputFolder = char(p.Results.outputFolder);
 
 % If the input folder does not exist, raise an error
 if isempty(inputFolder)
     error('No input folder specified');
 end
 
-% Name the output folder based on the input folder, vigilance and warp factor
-outputFolder = inputFolder + "_" + string(vigilance) + "_" + string(warpFactorLevel);
+if isempty(outputFolder)
+    % Name the output folder based on the input folder, vigilance and warp factor
+    outputFolder = [inputFolder '_' num2str(vigilance) '_' num2str(warpFactorLevel)];
+end
+
 
 if ~exist(outputFolder, 'dir')
 % If a folder with this name doesn't exist yet, make a

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Press **Enter** to use the default value.
 - **resample** (default: `1`) - `1 = yes`, `0 = no`
 - **sampleInterval** (default: `0.01` seconds) - must be a positive number
 - **compareWarped** (default: `0`) - `1 = yes`, `0 = no`
+- **outputFolder** (optional) - must be a string
 All optional inputs are validated. Invalid entries will trigger a re-prompt.
 
 ---


### PR DESCRIPTION
# Description

As identified by @olexandr-konovalov, the ability to manually specify the output folder name was removed when the default naming convention (input-folder-name_vigilance_warp-level) was introduced. This PR restores that flexibility by allowing users to optionally override the automatically generated folder name.

## Testing

The updated functionality was tested in two scenarios, both using the command builder:
- specifying a custom output folder name (test3)
- using the default naming behaviour when no output folder is provided

```bash
>> ARTwarp_cli_mode('OCEAN10', 3, 95, 10, 10, 'outputFolder', 'test3')

--- INPUT PARAMETERS ---

inputFolder       : OCEAN10
warpFactorLevel   : 3
vigilance         : 95
maxNumCategories  : 10
maxNumIterations  : 10
bias              : 1e-06
learningRate      : 0.1
resample          : 1
sampleInterval    : 0.01
compareWarped     : 0
recatSingleCats   : 0
outputFolder      : test3

--- ITERATIONS ---

Iteration 1 complete
Reclassified samples : 10
Current categories   : 6

Iteration 2 complete
Reclassified samples : 0
Current categories   : 6

ARTwarp CLI mode run finished.
Results successfully exported to: test3
```

```bash
Generated command:
ARTwarp_cli_mode('OCEAN10', 3, 95, 10, 10)

Do you want to proceed? (y/n) y

--- INPUT PARAMETERS ---

inputFolder       : OCEAN10
warpFactorLevel   : 3
vigilance         : 95
maxNumCategories  : 10
maxNumIterations  : 10
bias              : 1e-06
learningRate      : 0.1
resample          : 1
sampleInterval    : 0.01
compareWarped     : 0
recatSingleCats   : 0
outputFolder      : OCEAN10_95_3

--- ITERATIONS ---

Iteration 1 complete
Reclassified samples : 10
Current categories   : 7

Iteration 2 complete
Reclassified samples : 0
Current categories   : 7

ARTwarp CLI mode run finished.
Results successfully exported to: OCEAN10_95_3
```

 