### PR TITLE
Fix `freqCol` validation to allow `freqCol` = 1

### DIFF
--- a/TempRes3.m
+++ b/TempRes3.m
@@ -50,8 +50,8 @@ if ~isfolder(folder_name)
 end
 
 % Validate freqCol
-if isnan(freqCol) || mod(freqCol,1) ~= 0 || freqCol <= 1
-    errordlg('freqCol must be an integer greater than 1.', 'Invalid Input');
+if isnan(freqCol) || mod(freqCol,1) ~= 0 || freqCol <= 0
+    errordlg('freqCol must be a positive integer.', 'Invalid Input');
     return;
 end
 


### PR DESCRIPTION
`TempRes3` currently includes validation for `freqCol` here:
https://github.com/dolphin-acoustics-vip/artwarp/blob/ee135f79f56e0c5cfcddd0edbb79e5e8a46d1e5b/TempRes3.m#L53
https://github.com/dolphin-acoustics-vip/artwarp/blob/ee135f79f56e0c5cfcddd0edbb79e5e8a46d1e5b/TempRes3.m#L54
As @RosieDay-Reader mentions, allowed `freqCol` values must also include 1 because in some input `.csvs`, the frequency values are contained in column 1.